### PR TITLE
Renamed method ask to query in usbtmc class to accomodate changes mad…

### DIFF
--- a/ThorlabsPM100/usbtmc.py
+++ b/ThorlabsPM100/usbtmc.py
@@ -17,7 +17,7 @@ class USBTMC(object):
             length = 4000
         return os.read(self.FILE, length)
 
-    def ask(self, command, length=None):
+    def query(self, command, length=None):
         self.write(command)
         return self.read(length=length).decode('ascii')
 


### PR DESCRIPTION
…e in b269b3c8500482fb865cfbdc7581f4554b8b8bff for pyvisa

queries fail with 

 `File "/usr/local/lib/python3.8/dist-packages/ThorlabsPM100/VISA_wrapper_metaclass.py", line 201, in get_val`
 `   value = self._ask('%s' % ' '.join(cmd_nameb))`
 `File "/usr/local/lib/python3.8/dist-packages/ThorlabsPM100/ThorlabsPM100.py", line 26, in _ask`
 `   out = self._inst.query(cmd)`
 `AttributeError: 'USBTMC' object has no attribute 'query'`

when using USBTMC. Renaming USBTMC.ask() to USBTMC.query() fixes that